### PR TITLE
Adds regex data for youtube channel URL pattern

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -113,6 +113,12 @@ export const patterns = [{
 	tags:"video,youtube,url"
 },
 {
+	name:"ID of Youtube Channel",
+	regex: /https?:\/\/(www\.)?youtube.com\/channel\/UC([-_a-z0-9]{22})/i,
+	description:"Match the ID of a youtube channel URL",
+	tags:"channel,youtube,url"
+},
+{
 	name:"CSS comment",
 	regex:/\/\*[^*]*\*+([^/*][^*]*\*+)*\//,
 	description:"Match standard CSS comments",


### PR DESCRIPTION
Sample URL: https://www.youtube.com/channel/UClxGlpO6TzyJcW7gPCJe94g

Dissecting it, it has a regular URL pattern in the beginning with subroute /channel, and then an ID that will ALWAYS begin with UC, followed by 22 characters that can be numbers, letter, a hypen, or an underscore. Not more and not less than 22.