### PR TITLE
Amend email regex

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -36,8 +36,8 @@ export const patterns = [{
 },
 {
 	name:"Email",
-	regex:/^([a-z0-9+_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,24})$/,
-	description:"Match standards complient email addresses",
+	regex:/^.+@.+$/,
+	description:"Match standards complient email addresses. A stricter regex fully compliant with the standards is considered too complex to maintain. To actually verify an email address sending a conformation email is the only valid test.",
 	tags:"email,validation"
 },
 {


### PR DESCRIPTION
It is a common misconseption that email addresses can be verified with a
simple regex. This is not true, and implementing one only frustrates
users and developers. The best you can do as developer is:

* Verify that the email address has an at-mark (@) and something before
  and after it
* Send a confirmation email to validate the address

This requires only a trivial regex that will accept anything in the
(very complex) standard (including the valid `mail.from.amazon+"Bob
J@nes"@google`). Note that this regex does not check for a period in the
domain part of the address; with the availability of privately owned
top-level domains, there is no guarantee that the domain part will
necessarily contain a period when these domains gain wide-spread use
(think `@google`, `@apple`).

See also:
    https://stackoverflow.com/questions/201323/using-a-regular-expression-to-validate-an-email-address/201378#201378