### PR TITLE
Improved image SRC regex.

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -42,7 +42,7 @@ export const patterns = [{
 },
 {
 	name:"SRC of image tag",
-	regex:/\< *[img][^\>]*[src] *= *[\"\']{0,1}([^\"\'\ >]*)/,
+	regex:/^<\s*img[^>]+src\s*=\s*(["'])(.*?)\1[^>]*>$/,
 	description:"Match the src attribute of an HTML image tag",
 	tags:"html,tag,image"
 },


### PR DESCRIPTION
Previously even things like `<m c="a` would match, with the "SRC" being "`a`". This fixes a lot of the mistakes, but it's not perfect (shouldn't be parsing HTML with regex...).