### PR TITLE
A space between the backslash is valid for a self closing tag.

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -12,7 +12,7 @@ export const patterns = [{
 },
 {
 	name:"HTML tags",
-	regex:/^<([a-z1-6]+)([^<]+)*(?:>(.*)<\/\1>|\s+\/>)$/,
+	regex:/^<([a-z1-6]+)([^<]+)*(?:>(.*)<\/\1>| *\/>)$/,
 	description:"Match opening and closing HTML tags with content between",
 	tags:"markup,xml,html"
 },


### PR DESCRIPTION
For example <img /> (what the previous regex found) as well as <img/> is valid markup for a self closing tag. 