### PR TITLE
URL protocols and typo

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -54,8 +54,8 @@ export const patterns = [{
 },
 {
 	name:"URL",
-	regex:/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/,
-	description:"Match URL with optional protocal",
+	regex:/^((https?|ftp|file):\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/,
+	description:"Match URL with optional protocol",
 	tags:"url,address,http"
 },
 {


### PR DESCRIPTION
URLs are not bound to the http protocol.
The ftp and file protocols have the same syntax with http so they can be easily implemented.

Great work by the way.