### PR TITLE
Email RegEx Seeks TLD

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -42,7 +42,7 @@ export const patterns = [{
 },
 {
 	name:"Email",
-	regex:/^.+@.+$/,
+	regex:/^.+@.+\..+$/,
 	description:"Verify that there is an @ symbol with something before it",
 	tags:"email,validation"
 },


### PR DESCRIPTION
With original regex, jeff@j is considered valid.  With new regex, jeff@j is null but jeff@j.com is valid.