### PR TITLE
Added an Address-Parsing Regex

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -183,5 +183,11 @@ export const patterns = [{
 	regex:/^[+-<>.,\[\] \t\n\r]+$/,
 	description:"Matches valid code for a brainfuck program.",
 	tags:"brainfuck, code"
+},
+{
+	name:"Formatted Address",
+	regex:/^([^\n\r,]+)[\s,]+([^\n\r,]+[\s,]+)?([^\n\r,]+),\s+([A-Za-z]+)?[\s]?([0-9\-]+)?(?:[\s,]+([A-Za-z ]+))?$/,
+	description:"Matches formatted addresses include multi-line addresses.  Not foolproof; Street, City, and State must exist at minimum.  Match 1: address. Match 2: Apt/Suite/Unit #, if exist. Match 3: City. Match 4: State.  Match 5: Postal Code.  Match 6: Country",
+	tags:"address"
 }
 ];


### PR DESCRIPTION
Regex which parses a multi-line address into its component parts.  Address can be formatted as a single line with commas, or multiple lines.  This can probably be made better by someone smarter than myself as it is currently not foolproof.  At a minimum, the Street, City, and State must exist, otherwise nothing will match or the match will be incorrect.

### The matches are as follows
1. Match 1: Street address.
2. Match 2: Apt/Suite/Unit #
3. Match 3: City.
4. Match 4: State.
5. Match 5: Postal Code.
6. Match 6: Country

### Examples of addresses which match:
123 Easy Way
Somecity, AK

123 Easy Way
Unit 1
Somecity, AK 12345 USA

123 Easy Way, Somecity, AK

123 Easy Way, Unit 1, Somecity, AK 12345 USA