### PR TITLE
Add French ZIP/Postal Code

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -167,6 +167,12 @@ export const patterns = [{
 	tags:"address, postal, zip"
 },
 {
+	name:"French ZIP/Postal Code",
+	regex:/^([0-8]\d|9[^\D6])\d{3}|29[SN]\d{2}$/,
+	description:"Matches FR ZIP/Postal Code",
+	tags:"address, postal, zip"
+},
+{
 	name:"Morse Code",
 	regex:/^[.-]{1,5}(?:[ \t]+[.-]{1,5})*(?:[ \t]+[.-]{1,5}(?:[ \t]+[.-]{1,5})*)*$/,
 	description:"Matches valid Morse Code",


### PR DESCRIPTION
Ranges:  
- `00000` to `00999`: army exclusive usage
- `01000` to `95999`: metropolitan zip codes
- `97000` to `97999`: overseas department (DOM)
- `98000` to `98999`: overseas territory (TOM)
- `99000` to `99999`: reserved for special service "La Poste Paris Entreprise"

Special cases:
- `29Sxx` and `29Nxx` (Finistère) no longer exist since 1972, but are supported by this regex
- `2Axxx` and `2Bxxxx` (Corse) don't exist as zip codes (they are both merged into `20xxx`)
- `96xxx` is the only range unused in French zip codes