### PR TITLE
Fix URL regex when detecting multiple dots

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -54,7 +54,7 @@ export const patterns = [{
 },
 {
 	name:"URL",
-	regex:/^((https?|ftp|file):\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/,
+	regex:/^((https?|ftp|file):\/\/)?([\da-z-]+\.)+([a-z]{2,6})([\/\w \.-]*)*\/?$/
 	description:"Match URL with optional protocol",
 	tags:"url,address,http"
 },


### PR DESCRIPTION
Original regex is detecting multiple dots that written next to
each other. for example "hello......." would detected by the regex

Moved the dot character from character group so that only one dot
will be detected