### PR TITLE
change email regex to a valid and standard one

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -42,7 +42,7 @@ export const patterns = [{
 },
 {
 	name:"Email",
-	regex:/^.+@.+$/,
+	regex:/(?:[\w!#$%&'*+=?^_\/{|}`~-]+(?:\.[\w!#$%&'*+=?^_`{|}~-]+)*)@(?:(?:\w(?:\w*\w)?\.)+\w(?:\w*\w)?)/,
 	description:"Verify that there is an @ symbol with something before it",
 	tags:"email,validation"
 },


### PR DESCRIPTION
old regex for some case is invalid and not worked
for example abc...def@gmail.com is invalid 
and ?abc?@gmail.com is invalid because email must not start and end with symbol but old regex get it
thanks 